### PR TITLE
Correct description of moveTo() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ $.fn.fullpage.moveSectionDown();
 ```
 ---
 ### moveTo(section, slide)
-[Demo](http://codepen.io/alvarotrigo/pen/doqOmY) Scrolls the page to the given section and slide. The first slide, the visible one by default, will have index 0.
+[Demo](http://codepen.io/alvarotrigo/pen/doqOmY) Scrolls the page to the given section and slide. The first slide, the visible one by default, will have index 1.
 ```javascript
 /*Scrolling to the section with the anchor link `firstSlide` and to the 2nd Slide */
 $.fn.fullpage.moveTo('firstSlide', 2);


### PR DESCRIPTION
Docs say first slide has index 0 but when logging index using afterLoad, first section is 1 and all subsequent slides are +1